### PR TITLE
Fix error handling in seamless wrappers

### DIFF
--- a/NOTEBOOK/seamless-gemma.py
+++ b/NOTEBOOK/seamless-gemma.py
@@ -79,21 +79,23 @@ class SeamlessWrapper(nn.Module):
         else:
             pad_len = 0
 
+        x_processed = None
         try:
             x_processed = self.module(x)
-            if pad_len:
-                pad_slice = x_processed[:, -1:, :].expand(batch_size, pad_len, hidden_dim)
-                x_processed = torch.cat([x_processed, pad_slice], dim=1)
-            x_reshaped = x_processed.view(batch_size, sqrt_val, sqrt_val, hidden_dim)
-            x_wrapped = wrap_tensor(x_reshaped)
-            new_seq_len = (sqrt_val + 2) ** 2
-            x_final = x_wrapped.view(batch_size, new_seq_len, hidden_dim)
-            x_final = x_final[:, :seq_len, :]
-            logger.info("Seamless wrapping applied successfully.")
-            return x_final
         except Exception as e:
-            logger.error(f"Error during seamless wrapping: {e}. Returning original output.")
-            return x_processed
+            logger.error(f"Error during seamless wrapping: {e}. Returning original input.")
+            return x
+
+        if pad_len:
+            pad_slice = x_processed[:, -1:, :].expand(batch_size, pad_len, hidden_dim)
+            x_processed = torch.cat([x_processed, pad_slice], dim=1)
+        x_reshaped = x_processed.view(batch_size, sqrt_val, sqrt_val, hidden_dim)
+        x_wrapped = wrap_tensor(x_reshaped)
+        new_seq_len = (sqrt_val + 2) ** 2
+        x_final = x_wrapped.view(batch_size, new_seq_len, hidden_dim)
+        x_final = x_final[:, :seq_len, :]
+        logger.info("Seamless wrapping applied successfully.")
+        return x_final
 
 
 def _is_feedforward_block(mod: nn.Module) -> bool:

--- a/NOTEBOOK/seamless_gemma.py
+++ b/NOTEBOOK/seamless_gemma.py
@@ -71,21 +71,23 @@ class SeamlessWrapper(nn.Module):
         else:
             pad_len = 0
 
+        x_processed = None
         try:
             x_processed = self.module(x)
-            if pad_len:
-                pad_slice = x_processed[:, -1:, :].expand(batch_size, pad_len, hidden_dim)
-                x_processed = torch.cat([x_processed, pad_slice], dim=1)
-            x_reshaped = x_processed.view(batch_size, sqrt_val, sqrt_val, hidden_dim)
-            x_wrapped = wrap_tensor(x_reshaped)
-            new_seq_len = (sqrt_val + 2) ** 2
-            x_final = x_wrapped.view(batch_size, new_seq_len, hidden_dim)
-            x_final = x_final[:, :seq_len, :]
-            log("Seamless wrapping applied successfully.")
-            return x_final
         except Exception as e:
-            log(f"Error during seamless wrapping: {e}. Returning original output.")
-            return x_processed
+            log(f"Error during seamless wrapping: {e}. Returning original input.")
+            return x
+
+        if pad_len:
+            pad_slice = x_processed[:, -1:, :].expand(batch_size, pad_len, hidden_dim)
+            x_processed = torch.cat([x_processed, pad_slice], dim=1)
+        x_reshaped = x_processed.view(batch_size, sqrt_val, sqrt_val, hidden_dim)
+        x_wrapped = wrap_tensor(x_reshaped)
+        new_seq_len = (sqrt_val + 2) ** 2
+        x_final = x_wrapped.view(batch_size, new_seq_len, hidden_dim)
+        x_final = x_final[:, :seq_len, :]
+        log("Seamless wrapping applied successfully.")
+        return x_final
 
 # Wrap Feed-Forward Modules
 wrap_counter = 0


### PR DESCRIPTION
## Summary
- make error handling robust in `SeamlessWrapper` implementation in both notebooks

## Testing
- `python -m py_compile inference.py NOTEBOOK/seamless_gemma.py NOTEBOOK/seamless-gemma.py`

------
https://chatgpt.com/codex/tasks/task_e_685a4ecc78948324a7cdf9befeaac587