### PR TITLE
Fix error handling in SeamlessWrapper

### DIFF
--- a/NOTEBOOK/seamless-gemma.py
+++ b/NOTEBOOK/seamless-gemma.py
@@ -81,6 +81,11 @@ class SeamlessWrapper(nn.Module):
 
         try:
             x_processed = self.module(x)
+        except Exception as e:
+            logger.error(f"Error executing wrapped module: {e}. Returning input.")
+            return x
+
+        try:
             if pad_len:
                 pad_slice = x_processed[:, -1:, :].expand(batch_size, pad_len, hidden_dim)
                 x_processed = torch.cat([x_processed, pad_slice], dim=1)
@@ -92,7 +97,9 @@ class SeamlessWrapper(nn.Module):
             logger.info("Seamless wrapping applied successfully.")
             return x_final
         except Exception as e:
-            logger.error(f"Error during seamless wrapping: {e}. Returning original output.")
+            logger.error(
+                f"Error during seamless wrapping: {e}. Returning original output."
+            )
             return x_processed
 
 

--- a/NOTEBOOK/seamless_gemma.py
+++ b/NOTEBOOK/seamless_gemma.py
@@ -73,6 +73,11 @@ class SeamlessWrapper(nn.Module):
 
         try:
             x_processed = self.module(x)
+        except Exception as e:
+            log(f"Error executing wrapped module: {e}. Returning input.")
+            return x
+
+        try:
             if pad_len:
                 pad_slice = x_processed[:, -1:, :].expand(batch_size, pad_len, hidden_dim)
                 x_processed = torch.cat([x_processed, pad_slice], dim=1)


### PR DESCRIPTION
## Summary
- handle failures when executing wrapped module in SeamlessWrapper

## Testing
- `python -m py_compile NOTEBOOK/seamless-gemma.py NOTEBOOK/seamless_gemma.py inference.py`

------
https://chatgpt.com/codex/tasks/task_e_685a4ecc78948324a7cdf9befeaac587