### PR TITLE
Resolve docs placeholder names

### DIFF
--- a/DOC/SEAMLESS.md
+++ b/DOC/SEAMLESS.md
@@ -44,7 +44,7 @@ def log(message):
 # We'll load Gemma 3 1B and do a quick inspection. (Adjust the model ID if needed.)
 
 # %% [code]
-model_name = "google/deepmind-gemma-3-1b"  # Replace with the actual Hugging Face model ID
+model_name = "google/gemma-3-1b-pt"  # Default 1B pretrained checkpoint
 try:
     log(f"Loading model {model_name} ...")
     model = AutoModelForCausalLM.from_pretrained(model_name)

--- a/DOC/STRIPPER.md
+++ b/DOC/STRIPPER.md
@@ -24,7 +24,7 @@ import torch.nn as nn
 from transformers import AutoModelForCausalLM, AutoTokenizer
 
 # Replace this with the actual model ID if different
-model_name = "google/deepmind-gemma-3-27b"  # Hypothetical model ID
+model_name = "google/gemma-3-27b-it"  # Default 27B instruction-tuned checkpoint
 print(f"Loading model {model_name}...")
 
 # Load the Gemma 3 model and tokenizer

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+torch
+transformers


### PR DESCRIPTION
## Summary
- use open Gemma model IDs in docs
- add simple requirements list for basic installation

## Testing
- `pycodestyle inference.py NOTEBOOK/seamless-gemma.py NOTEBOOK/seamless_gemma.py | head`
- `python -m py_compile inference.py NOTEBOOK/seamless-gemma.py NOTEBOOK/seamless_gemma.py`
- `pip install -r requirements.txt` *(fails: Operation cancelled due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_685b59cc86d48324b36a0d7660a32a61