### PR TITLE
Fix packaging for inference script

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,3 +19,6 @@ gemcraft-seamless = "gemcraft.seamless:main"
 where = ["."]
 include = ["gemcraft*"]
 exclude = ["DATAFORGE*", "DOC*", "NOTEBOOK*"]
+
+[tool.setuptools]
+py-modules = ["inference"]


### PR DESCRIPTION
## Summary
- ensure `inference.py` is included in builds

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e15f63d408324ba1c7dd3d6541766